### PR TITLE
Fixed a bug with accessing a private variable on a class, and uninstalled adapter for blocks on install

### DIFF
--- a/user/addons/assets_adapter_for_bloqs/ext.assets_adapter_for_bloqs.php
+++ b/user/addons/assets_adapter_for_bloqs/ext.assets_adapter_for_bloqs.php
@@ -11,6 +11,9 @@ class Assets_adapter_for_bloqs_ext {
 
 	public function activate_extension()
 	{
+		// Upon activating this extension, delete the Assets adapter for blocks
+		ee()->db->query("DELETE FROM exp_extensions WHERE class = 'Assets_adapter_for_blocks_ext'");
+
 		ee()->db->insert('extensions', array(
 			'class'    => AAFB_CLASSNAME,
 			'method'   => 'blocks_discover_fieldtypes',

--- a/user/addons/assets_adapter_for_bloqs/ext.assets_adapter_for_bloqs.php
+++ b/user/addons/assets_adapter_for_bloqs/ext.assets_adapter_for_bloqs.php
@@ -47,7 +47,7 @@ class Assets_adapter_for_bloqs_ext {
 		// If Assets is already a valid fieldtype, don't do anything. I mean,
 		// other than celebrate that this adapter is no longer necessary.
 		foreach ($fieldtypes as $fieldtype) {
-			if ($fieldtype->type === 'assets') {
+			if ($fieldtype->getType() === 'assets') {
 				return $fieldtypes;
 			}
 		}


### PR DESCRIPTION
When activating this extension, it will delete the `Assets_adapter_for_blocks_ext` since you are now obviously not using it. Leaving it in there will throw errors once you remove the files for the addon. This update process is consistent with the Blocks -> Bloqs upgrade process.

This was also trying to access $fieldtype->type, which in the latest Bloqs, is private.